### PR TITLE
Dummy Suspiciousness Verdict

### DIFF
--- a/Jakub_IDS.lua
+++ b/Jakub_IDS.lua
@@ -261,3 +261,4 @@ function sus_p.dissector(tvb, pinfo, tree)
 	tree:set_generated()
 
 end
+


### PR DESCRIPTION
Creates a dummy suspiciousness measure to "check" if a packet is malicious or benign. 

Partially adapted from: https://wiki.wireshark.org/Lua/Examples/PostDissector

---

###  Things I learned:
* Post-dissectors allow for modifying the dissection tree without having to remake the dissector from scratch, very useful
* Packets cannot be recoloured using code without making the user manually change their colouring preferences
* ProtoField.string() can be easily confused with ProtoField.Float(). Yes, finding the bug took years off my life
* If statements are annoyingly verbose to write
* ~81 000 packets take ~3 seconds to process with this post-dissector, maybe it's a good idea to switch to C++?