### PR TITLE
Content Normalisation

### DIFF
--- a/Jakub_IDS.lua
+++ b/Jakub_IDS.lua
@@ -350,6 +350,9 @@ function sus_p.dissector(tvb,pinfo,tree)
 	else
 		is_sus = "Benign"
 		reason = "The packet did not trigger any rules."
+		if result[2] ~= nil then
+			reason = reason .. "\n()" .. result[2] .. ")"
+		end
 	end
 
 	if pinfo.in_error_pkt then -- return value for error packets
@@ -363,7 +366,6 @@ function sus_p.dissector(tvb,pinfo,tree)
 	tree:add_le(sus_reason_field, reason)
 	--tree:add(sus_reason_field, reason)
 	tree:set_generated()
-
 end
 
 --------------------------------------------------------------------------------
@@ -690,13 +692,13 @@ local function ShowSignatures()
 			txt = txt .. "Signature SID " .. sid .. ":\n"
 			for key, value in pairs(signature) do
 				if type(value) == "table" then -- multi-valued inputs
-					txt = txt .. "  " .. key .. ": {"
+					txt = txt .. "  " .. key .. ": {\n"
 					for k, v in pairs(value) do
-						txt = txt .. k .. "=" .. v .. ","
+						txt = txt .. "          " .. k .. "=" .. v .. "\n"
 					end
-					txt = txt .. "}\n"
+					txt = txt .. "  }\n"
 				else
-					txt = txt .."  *" .. key .. "*: " .. value .. "\n"
+					txt = txt .."  " .. key .. ": " .. value .. "\n"
 				end
 			end
 		end


### PR DESCRIPTION
This PR aims to normalise the `content` options in SNORT rules. For example, a SNORT rule may look like:
```lua
content:"2|00 00 00 06 00 00 00|Drives|24 00|",depth 16;
```
The parts between the pipes `|` are hexadecimal values, and the strings outside are ascii strings. The function introduced in this PR normalises this so that it's all bytes, like so:

```lua
content:"32000000060000004472697665732400"
```
This is necessary because the Boyer-Moore-Horspool and other string search functions are dumb and can't do this themselves. Without this, none of the content matching would work. Ever.

---

###  Things I learned:
* SNORT rules are annoying to check against when each protocol and option has a bazillion different arguments and sub-options
* The scope, once again, was too broad
* I have no clue how I will realistically test this against SNORT
* I need a better cooling fan and a quantum computer if I want to analyse any file >300MB
* It can analyse(?) packets in real time though!