### PR TITLE
Alert Logger Outputs To File

### DIFF
--- a/Jakub_IDS.lua
+++ b/Jakub_IDS.lua
@@ -765,5 +765,12 @@ function LogAlert(tvb, tree, pinfo, sid)
 	output = output .. "\n"
 
 	--printd(output) -- debug print
+	local file = io.open(path .. "alert.log", "a")
+	if not file then
+		printd(path .. "alert.log could not be opened")
+	end
+	file:write(output)
+	file:close()
+	
 	return output
 end


### PR DESCRIPTION
The Alert Logger has been improved to log alert outputs in the aptly named `alert.log` file. This file's path is determined from the base plugin path, so if that's wrong then it will all break. Oh well! I can't be bothered to fix that.

---

###  Things I learned:
* If I make a thousand PRs with one commit each it will look like I did more work!
* Procrastination sucks more when you have a lot of other things to do as an excuse
* Lua sucks when it comes to arrays/tables/lists/somethings
* (I'm only saying that because I forgot my `options` table was a 2D array/table/list/something)