### PR TITLE
IP Confidence Check

### DIFF
--- a/Jakub_IDS.lua
+++ b/Jakub_IDS.lua
@@ -353,7 +353,6 @@ function sus_p.dissector(tvb,pinfo,tree)
 	-- Blacklist updating
 	local current_time = pinfo.rel_ts
 	if current_time - timer > 5 then
-		printd(current_time - timer)
 		SaveBlacklist("blacklist.csv")
 		timer = current_time
 	end
@@ -548,7 +547,6 @@ end
 
 
 -- TODO: UPDATE BLACKLIST AND OUTPUT TO FILE (every 5 seconds)
--- ALL PACKETS ARE MARKED AS SUSPICIOUS, FIX THAT
 -- WU-MANBER ALGORITHM
 -- DETERMINE WHERE TO USE WU-MANBER ALGORITHM
 -- ANALYSE DIFFERENT RULES? - RIGHT NOW ONLY THE FIRST ONE TO MATCH IT OUTPUT (this is good for most cases but makes the blacklist look simple/wrong)
@@ -582,6 +580,7 @@ function SignatureCheck(tvb, pinfo, tree, sid)
 		-- content matching here
 		-- Boyer-Moore-Horspool since it is a single signature search
 		local first_145_bytes = tostring(tvb:range(0, math.min(tvb:len(), 145)):bytes()) -- Wheeler (2006) says that only 145 bytes are needed to check 95% of SNORT rules
+		printd(first_145_bytes .. "\n" .. signature["options"]["content"] .. "\n")
 		if BoyerMooreHorspool(first_145_bytes, signature["options"]["content"]) == -1 then
 			return {-1}
 		end

--- a/Jakub_IDS.lua
+++ b/Jakub_IDS.lua
@@ -242,7 +242,17 @@ end
 
 
 function SaveBlacklist(filename) -- saves the blacklist to a file
-	local file = io.open(path .. filename, "w") -- Open the file for writing
+	-- Assessing if an entry should remain in the blacklist
+	-- Using Meng et al.'s IP confidence equation
+	for ip, values in pairs(blacklisted_IPs) do
+		local IP_confidence = values[1] / (10 * values[2])
+		if IP_confidence >= 1 then
+			blacklisted_IPs[ip] = nil
+		end
+	end
+
+	-- Ssaving to file
+	local file = io.open(path .. filename, "w")
 	if not file then 
 		printd("Error: Unable to open file " .. filename .. " for writing")
 		return -1


### PR DESCRIPTION
When I first implemented the `SaveBlacklist()` function, I completely forgot that it's meant to perform Meng et al's (2014) calculation for IP confidence. It can be summed up as follows:

![image](https://github.com/Jakub-Jedruszczak/Wireshark-IDS/assets/125093474/693ef3ae-6ca0-4d79-98af-04679922934a)

No I will not elaborate.
All you need to know is that I finally implemented it so that IP's with high confidence are finally wiped from the CSV.

---

###  Things I learned:
* My code is 20% comments but I can't read
* Calculations with good and bad packets are easy (if you keep track of both...)
* `printd()` is the only fully working function in my code
* Happy 21st PR!