### PR TITLE
Fixes The Port Check For The Signatures

### DIFF
--- a/Jakub_IDS.lua
+++ b/Jakub_IDS.lua
@@ -573,9 +573,13 @@ function SignatureCheck(tvb, pinfo, tree, sid)
 	if string.find(tostring(frame_protocols_f()), signature["protocol"]) == nil then
 		return {-1}
 	end
-	--if (tostring(pinfo.src_port) ~= signature["source port"] and tostring(pinfo.src_port) ~= "any") or (tostring(pinfo.dst_port) ~= signature["destination port"] and tostring(pinfo.dst_port) ~= "any") then
-	--	return {-1}
-	--end
+	-- Check if packet ports match signature ports
+	if signature["source port"] ~= "any" and signature["source port"] ~= tostring(pinfo.src_port) then
+		return {-1}
+	end
+	if signature["destination port"] ~= "any" and signature["destination port"] ~= tostring(pinfo.dst_port) then
+		return {-1}
+	end
 	if signature["options"]["content"] ~= nil then
 		-- content matching here
 		-- Boyer-Moore-Horspool since it is a single signature search


### PR DESCRIPTION
This PR fixes the port check for the signatures, which did not work at all because the logic was wrong. Now the logic is not wrong.

This time I will elaborate for your viewing pleasure.

For this example we will need some variables:
`PS` = Packet Source port
`PD` = Packet Destination port
`SS` = Signature Source port
`SD` = Signature Destination port

Let's start with an initial check; the code should work if the packet's ports match those of the signature, like so:

`(PS == SS) AND (PD == SD)`

However, we also have to consider that the rule could have the `any` keyword in the rule. That means that the code has to be modified:

`((PS == SS) OR (SS == "any")) AND ((PD == SD) OR (SD == "any"))`

This would work all well and good in a normal block of code. However, since I can't do normal blocks of code, it has to be inverted. We can do this using Boolean algebra. 

We have to use De Morgan's Law, which states that:

`NOT (A AND B) = NOT A OR NOT B`

Therefore, we can modify our code into this:

`((PS != SS) AND (SS != "any")) AND ((PD != SD) AND (SD != "any"))`

Implemented as Lua code, it will look like:

```lua
if (signature["source port"] ~= "any" and signature["source port"] ~= tostring(pinfo.src_port)) and (signature["destination port"] ~= "any" and signature["destination port"] ~= tostring(pinfo.dst_port)) then
		return {-1} -- end check
	end
```
However this doesn't look very good, so it should be split onto multiple lines:

```lua
if signature["source port"] ~= "any" and signature["source port"] ~= tostring(pinfo.src_port) then
		return {-1}
	end
	if signature["destination port"] ~= "any" and signature["destination port"] ~= tostring(pinfo.dst_port) then
		return {-1}
	end
```

---

###  Things I learned:
* I will never be able to escape De Morgan and his stupid rule
* Boolean Algebra is not fun and never will be
* That doesn't mean it's not useful